### PR TITLE
Try harder to shorten request strings

### DIFF
--- a/core/model/relval.py
+++ b/core/model/relval.py
@@ -248,6 +248,18 @@ class RelVal(ModelBase):
                 # Avoid infinite loop
                 break
 
+        # Try harder if we didn't succeed -- we need to cut the suffix
+        if len(request_string) > 72:
+            self.logger.debug('Request string %s too long (%s char)',
+                              request_string,
+                              len(request_string))
+            # Shorten each "word" in the suffix to at most 3 characters
+            suffix = '_'.join(part[:3] for part in suffix.split('_'))
+            request_string = f'RV{cmssw_release}{relval_name}__{suffix}'.strip('_')
+            self.logger.debug('Request string shortened to %s (%s char)',
+                              request_string,
+                              len(request_string))
+
         return request_string
 
     def get_name(self):


### PR DESCRIPTION
Request strings could still exceed 72 chars when the suffix was long enough. When this happens, try to shorten the suffixes by reducing each "word" to at most 3 characters.

Testing was minimal because I don't know how to setup a local relval machine. I only checked that the expression `'_'.join(part[:3] for part in suffix.split('_'))` worked on my local (which has Python 3.10).