### PR TITLE
Add  `data` Option for Matrix

### DIFF
--- a/core/model/model_base.py
+++ b/core/model/model_base.py
@@ -26,7 +26,7 @@ class ModelBase(PdmVModelBase):
         'globaltag': lambda gt: ModelBase.matches_regex(gt, ModelBase.__globaltag_regex),
         'label': lambda label: ModelBase.matches_regex(label, '[a-zA-Z0-9_]{0,75}'),
         'matrix': lambda m: m in ('standard', 'upgrade', 'generator',
-                                  'pileup', 'premix', 'extendedgen', 'gpu'),
+                                  'pileup', 'premix', 'extendedgen', 'gpu', 'data_highstats'),
         'memory': lambda mem: 0 <= mem <= 32000,
         'processing_string': lambda ps: ModelBase.matches_regex(ps, ModelBase.__ps_regex),
         'relval': lambda r: ModelBase.matches_regex(r, ModelBase.__relval_regex),

--- a/vue_frontend/src/components/RelValsEdit.vue
+++ b/vue_frontend/src/components/RelValsEdit.vue
@@ -44,6 +44,11 @@
               <option>standard</option>
               <option>upgrade</option>
               <option>generator</option>
+              <option>pileup</option>
+              <option>premix</option>
+              <option>extendedgen</option>
+              <option>gpu</option>
+              <option>data_highstats</option>
             </select>
           </td>
         </tr>

--- a/vue_frontend/src/components/TicketsEdit.vue
+++ b/vue_frontend/src/components/TicketsEdit.vue
@@ -92,6 +92,7 @@
               <option>premix</option>
               <option>extendedgen</option>
               <option>gpu</option>
+              <option>data_highstats</option>
             </select>
           </td>
         </tr>


### PR DESCRIPTION
This PR proposes to add the `data` option for the matrix to the frontend (and the backend checks). This is needed since we have a new matrix with new data workflow to submit from `14_1_0_pre7`.