### PR TITLE
Allow Event-based Input Skim with `das-up-to-nevents.py`

### DIFF
--- a/core/controller/ticket_controller.py
+++ b/core/controller/ticket_controller.py
@@ -255,6 +255,7 @@ class TicketController(ControllerBase):
                 "lumisection": {},
                 "run": [],
                 "label": "",
+                "events": 0,
             }
             input_step_json["name"] += "_Recycled"
             input_step = RelValStep(input_step_json, relval, False)
@@ -268,7 +269,6 @@ class TicketController(ControllerBase):
         """
         # Deal with input file part
         input_dict = step_dict.get("input", {})
-        input_dict.pop("events", None)
 
         # Deal with driver part
         arguments = step_dict.get("arguments", {})

--- a/core/model/relval_step.py
+++ b/core/model/relval_step.py
@@ -280,7 +280,25 @@ class RelValStep(ModelBase):
                 command += 'dasgoclient --limit 0 '
                 command += f'--query "file dataset={dataset} run in [{run_chunk}]" '
                 command += f'>> {files_name}\n'
+            return (comment + '\n' + command).strip()
 
+        events = input_dict['events']
+
+        ## N.B. das-up-to-nevents.py exists only from 14_1_0_pre7
+        cmssw_components = lambda x: x.strip().split("_")
+        cmssw_release = cmssw_components(self.get_release())
+        cmssw_release >= cmssw_components("14_1_0_pre7")
+
+        if events and check_das_up_to_nevents:
+            self.logger.info('Making a DAS command for step %s with max events', step_index)
+            files_name = f'step{step_index + 1}_files.txt'
+            comment = f'# Arguments for step {step_index + 1}:\n'
+            command = f'# Command for step {step_index + 1}:\n'
+            comment += f'#   dataset: {dataset}\n'
+            comment += f'#   events : {events}\n'
+            command += f'echo "" > {files_name}\n'
+            commnad += f'das-up-to-nevents.py -d {dataset} -e {events} --pc'
+            command += f'>> {files_name}\n'
             return (comment + '\n' + command).strip()
 
         return f'# Step {step_index + 1} is input dataset for next step: {dataset}'

--- a/core/model/relval_step.py
+++ b/core/model/relval_step.py
@@ -66,6 +66,7 @@ class RelValStep(ModelBase):
             'lumisection': {},
             'run': [],
             'label': '',
+            'events': '',
         },
         # Keeping output of this task
         'keep_output': True,
@@ -92,7 +93,9 @@ class RelValStep(ModelBase):
         },
         '_input': {
             'dataset': lambda ds: not ds or ModelBase.lambda_check('dataset')(ds),
-            'label': lambda l: not l or ModelBase.lambda_check('label')(l)
+            'label': lambda l: not l or ModelBase.lambda_check('label')(l),
+            'events': lambda m: m == '' or int(m) > 0,
+        },
         },
         'lumis_per_job': lambda l: l == '' or int(l) > 0,
         'name': lambda n: ModelBase.matches_regex(n, '[a-zA-Z0-9_\\-]{1,150}'),

--- a/core/model/relval_step.py
+++ b/core/model/relval_step.py
@@ -94,7 +94,7 @@ class RelValStep(ModelBase):
         '_input': {
             'dataset': lambda ds: not ds or ModelBase.lambda_check('dataset')(ds),
             'label': lambda l: not l or ModelBase.lambda_check('label')(l),
-            'events': lambda m: m == '' or int(m) > 0,
+            'events': lambda m: m == '' or (m.isnumeric() and int(m) > 0),
         },
         'lumis_per_job': lambda l: l == '' or int(l) > 0,
         'name': lambda n: ModelBase.matches_regex(n, '[a-zA-Z0-9_\\-]{1,150}'),

--- a/core/model/relval_step.py
+++ b/core/model/relval_step.py
@@ -66,7 +66,7 @@ class RelValStep(ModelBase):
             'lumisection': {},
             'run': [],
             'label': '',
-            'events': '',
+            'events': 0,
         },
         # Keeping output of this task
         'keep_output': True,
@@ -96,7 +96,6 @@ class RelValStep(ModelBase):
             'label': lambda l: not l or ModelBase.lambda_check('label')(l),
             'events': lambda m: m == '' or int(m) > 0,
         },
-        },
         'lumis_per_job': lambda l: l == '' or int(l) > 0,
         'name': lambda n: ModelBase.matches_regex(n, '[a-zA-Z0-9_\\-]{1,150}'),
         'scram_arch': lambda s: not s or ModelBase.lambda_check('scram_arch')(s),
@@ -112,12 +111,14 @@ class RelValStep(ModelBase):
                 json_input['gpu'] = schema.get('gpu')
                 json_input['gpu']['requires'] = 'forbidden'
                 step_input = json_input['input']
+             
                 for key, default_value in schema['input'].items():
                     if key not in step_input:
                         step_input[key] = default_value
             else:
                 json_input['driver'] = {k.lstrip('-'): v for k, v in json_input['driver'].items()}
                 json_input['input'] = schema.get('input')
+         
                 if json_input.get('gpu', {}).get('requires') not in ('optional', 'required'):
                     json_input['gpu'] = schema.get('gpu')
                     json_input['gpu']['requires'] = 'forbidden'
@@ -283,13 +284,13 @@ class RelValStep(ModelBase):
             return (comment + '\n' + command).strip()
 
         events = input_dict['events']
-
+        
         ## N.B. das-up-to-nevents.py exists only from 14_1_0_pre7
         cmssw_components = lambda x: x.strip().split("_")
         cmssw_release = cmssw_components(self.get_release())
-        cmssw_release >= cmssw_components("14_1_0_pre7")
-
-        if events and check_das_up_to_nevents:
+        check_das_up_to_nevents = cmssw_release >= cmssw_components("14_1_0_pre7")
+        
+        if events > 0 and check_das_up_to_nevents:
             self.logger.info('Making a DAS command for step %s with max events', step_index)
             files_name = f'step{step_index + 1}_files.txt'
             comment = f'# Arguments for step {step_index + 1}:\n'
@@ -297,7 +298,7 @@ class RelValStep(ModelBase):
             comment += f'#   dataset: {dataset}\n'
             comment += f'#   events : {events}\n'
             command += f'echo "" > {files_name}\n'
-            commnad += f'das-up-to-nevents.py -d {dataset} -e {events} --pc'
+            command += f'das-up-to-nevents.py -d {dataset} -e {events} '
             command += f'>> {files_name}\n'
             return (comment + '\n' + command).strip()
 
@@ -350,12 +351,16 @@ class RelValStep(ModelBase):
                     previous_input = previous.get('input')
                     previous_lumisection = previous_input['lumisection']
                     previous_run = previous_input['run']
+                    previous_events = previous_input['events']
                     if previous_lumisection:
                         # If there are lumi ranges, add a file with them and list of files as input
                         arguments_dict['filein'] = f'"filelist:step{index}_files.txt"'
                         arguments_dict['lumiToProcess'] = f'"step{index}_lumi_ranges.txt"'
                     elif previous_run:
                         # If there is a run whitelist, add the file
+                        arguments_dict['filein'] = f'"filelist:step{index}_files.txt"'
+                    elif previous_events:
+                        # If there is a max number of events, add the file
                         arguments_dict['filein'] = f'"filelist:step{index}_files.txt"'
                     else:
                         # If there are no lumi ranges, use input file normally


### PR DESCRIPTION
With https://github.com/cms-sw/cmssw/pull/45055 we can run data wfs skimming the input based on a maximum number of events (and relying on the golden data certification json). This PR proposes a way to allow the RelVal machine to use this new feature when the `InputInfo` includes a limit on `events` (and no limit on lumisections or runs).