### PR TITLE
Increase SpecialRV Priority and add HighPrio Setup

### DIFF
--- a/core/controller/relval_controller.py
+++ b/core/controller/relval_controller.py
@@ -322,14 +322,22 @@ class RelValController(ControllerBase):
         """
         campaign = relval.get_campaign()
         if "SpecialRV" in campaign:
-            priority = 200000
+            priority = 300000
             self.logger.info(
                 "Setting `RequestPriority` to %s because it includes the placeholder `SpecialRV` in the campaign name",
                 priority
             )
             return priority
-
-        return 500000
+            
+        if "HighPrio" in campaign:
+            priority = 500000
+            self.logger.info(
+                "Setting `RequestPriority` to %s because it includes the placeholder `HighPrio` in the campaign name",
+                priority
+            )
+            return priority
+            
+        return 450000
 
     def get_job_dict(self, relval):
         # pylint: disable=too-many-statements


### PR DESCRIPTION
This PR proposes to:
1. decrease the default RelVal priority to 450k in order to have room for high priority RelVals if we need them (500k) 
2. increase the SpecialRV priority to 300k to be always well above also the top priority MC samples (200k).
