### PR TITLE
Fix: Compatibility issues for Python 2 runs

### DIFF
--- a/core/utils/dqm.py
+++ b/core/utils/dqm.py
@@ -33,7 +33,7 @@ def list_certification_files(cert_type):
     url = "%s/%s/" % (dqm_cert_url, cert_type)
     page_content = requests.get(url=url, timeout=30)
     if page_content.status_code != 200:
-        error_msg = f"Unable to retrieve the content related to {cert_type}"
+        error_msg = "Unable to retrieve the content related to %s" % cert_type
         raise HTTPError(error_msg, response=page_content)
 
     # Parse the HTML and retrieve the file names
@@ -65,7 +65,7 @@ def get_certification_file(path):
     url = "%s/%s" % (dqm_cert_url, path)
     file = requests.get(url=url, timeout=30)
     if file.status_code != 200:
-        error_msg = f"Unable to retrieve the content related to {path}"
+        error_msg = "Unable to retrieve the content related to %s" % path
         raise HTTPError(error_msg, response=file)
 
     return file.json()

--- a/core/utils/run_the_matrix_pdmv.py
+++ b/core/utils/run_the_matrix_pdmv.py
@@ -4,6 +4,7 @@ PdmV's simplified implementation of runTheMatrix.py
 from __future__ import print_function
 
 import argparse
+import codecs
 import importlib
 import inspect
 import json
@@ -312,7 +313,7 @@ def main():
     print('All workflows:')
     print(json.dumps(workflows, indent=2, sort_keys=True))
     if opt.output_file:
-        with open(opt.output_file, 'w', encoding='utf-8') as workflows_file:
+        with codecs.open(opt.output_file, 'w', encoding='utf-8') as workflows_file:
             json.dump(workflows, workflows_file)
 
 


### PR DESCRIPTION
Discovered at: #138 - [Details](https://github.com/cms-PdmV/RelVal/pull/138#issuecomment-2545872384)

Avoid compatibility errors with Python 2 for the `open(...)` function for setting the file's encoding and for string formatting too.

Sometimes in case an old architecture and `cms-sw` release is being used, a Python 2 interpreter is available for executing the `run_the_matrix_pdmv.py` module and there are compatibility issues.